### PR TITLE
Feat/renew decoder

### DIFF
--- a/src/OboeDecoder.bsv
+++ b/src/OboeDecoder.bsv
@@ -1,59 +1,28 @@
 package OboeDecoder;
+
 import OboeTypeDef::*;
 
-// Typedef: RType
-//   R-type instruction format.
-typedef struct {
-  Bit#(7) funct7;
-  ArchRegId rs2;
-  ArchRegId rs1;
-  Bit#(3) funct3;
-  ArchRegId rd;
-  Bit#(7) opcode;
-} RType deriving(Eq, Bits);
+// Function: immIType
+//   Generate I-type immediate value
+function Word immIType(IType inst) = signExtend(inst.imm);
 
-// Typedef: IType
-//   I-type instruction format.
-typedef struct {
-  Bit#(12) imm;
-  ArchRegId rs1;
-  Bit#(3) funct3;
-  ArchRegId rd;
-  Bit#(7) opcode;
-} IType deriving(Eq, Bits);
+// Function: immSType
+//   Generate S-type immediate value
+function Word immSType(SType inst) = signExtend({inst.imm2, inst.imm1});
 
-// Typedef: SType
-//   S-type instruction format.
-typedef struct {
-  Bit#(7) imm2;
-  ArchRegId rs2;
-  ArchRegId rs1;
-  Bit#(3) funct3;
-  Bit#(5) imm1;
-  Bit#(7) opcode;
-} SType deriving(Eq, Bits);
+// Function: immUType
+//   Generate U-type immediate value
+function Word immUType(UType inst) = {inst.imm, 12'd0};
 
-// Typedef: UType
-//   U-type instruction format.
-typedef struct {
-  Bit#(20) imm;
-  ArchRegId rd;
-  Bit#(7) opcode;
-} UType deriving(Eq, Bits);
+// Function: immJType
+//   Generate J-type immediate value
+function Word immJType(JType inst) = signExtend({inst.imm4, inst.imm3, inst.imm2, inst.imm1, 1'b0}); 
 
-// Typedef: OpCodeWidth
-typedef 7 OpCodeWidth;
+// Function: immBType
+//   Generate B-type immediate value
+function Word immBType(BType inst) = signExtend({inst.imm4, inst.imm3, inst.imm2, inst.imm1, 1'b0}); 
 
-Bit#(OpCodeWidth) op_imm    = 'b0010011;
-Bit#(OpCodeWidth) op_r      = 'b0110011;
-Bit#(OpCodeWidth) op_lui    = 'b0110111;
-Bit#(OpCodeWidth) op_auipc  = 'b0010111;
-Bit#(OpCodeWidth) op_jal    = 'b1101111;
-Bit#(OpCodeWidth) op_jalr   = 'b1100111;
-Bit#(OpCodeWidth) op_branch = 'b1100011;
-Bit#(OpCodeWidth) op_load   = 'b0000011;
-Bit#(OpCodeWidth) op_store  = 'b0100011;
-Bit#(OpCodeWidth) op_csr    = 'b1110011;
+TrapCause illegal_instruction = TrapCause {isInterrupt: False, code: 2};
 
 // Interface: OboeDecoder
 interface OboeDecoder;
@@ -73,33 +42,28 @@ endinterface
 //   Decoder module for oboe.
 module mkOboeDecoder(OboeDecoder);
 
-  // Function: opImmDecode
+  // Function: decodeOpImm
   //   Decode the instructions with opcode = OP_IMM.
-  function BackendInst opImmDecode(RawInst inst);
+  function BackendInst decodeOpImm(RawInst inst);
     IType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     AluCtrl alu_ctrl = AluCtrl {op: ADD, src: Rs1Imm};  // default value
-    Word i_imm = signExtend(inst[31:20]);
-
     Bool isInvalid = False;  // to check the decoding procedure is valid or not
+
     case (decoded_inst.funct3)
-      'b000: alu_ctrl = AluCtrl {op: ADD, src: Rs1Imm};
-      'b100: alu_ctrl = AluCtrl {op: XOR, src: Rs1Imm};
-      'b110: alu_ctrl = AluCtrl {op: OR, src: Rs1Imm};
-      'b111: alu_ctrl = AluCtrl {op: AND, src: Rs1Imm};
-      'b010: alu_ctrl = AluCtrl {op: LT, src: Rs1Imm};
-      'b011: begin 
-        i_imm = zeroExtend(decoded_inst.imm);
-        alu_ctrl = AluCtrl {op: LTU, src: Rs1Imm}; 
+      funct3_add:  alu_ctrl = AluCtrl {op: ADD, src: Rs1Imm};
+      funct3_xor:  alu_ctrl = AluCtrl {op: XOR, src: Rs1Imm};
+      funct3_or:   alu_ctrl = AluCtrl {op: OR,  src: Rs1Imm};
+      funct3_and:  alu_ctrl = AluCtrl {op: AND, src: Rs1Imm};
+      funct3_slt:  alu_ctrl = AluCtrl {op: LT,  src: Rs1Imm};
+      funct3_sltu: alu_ctrl = AluCtrl {op: LTU, src: Rs1Imm}; 
+      funct3_sll: begin
+        if (decoded_inst.imm[11:5] == 0)
+          alu_ctrl = AluCtrl {op: SLL, src: Rs1Imm};
+        else
+          isInvalid = True;
       end
-      'b001: begin 
-        i_imm = zeroExtend(decoded_inst.imm[4:0]);
-        alu_ctrl = AluCtrl {op: SLL, src: Rs1Imm};
-      end
-      'b101: begin 
-        i_imm = zeroExtend(decoded_inst.imm[4:0]);
-        if (inst[31:25] == 0)
+      funct3_srl: begin 
+        if (decoded_inst.imm[11:5] == 0)
           alu_ctrl = AluCtrl {op: SRL, src: Rs1Imm};
         else if (inst[31:25] == 'b0100000)
           alu_ctrl = AluCtrl {op: SRA, src: Rs1Imm};
@@ -110,327 +74,261 @@ module mkOboeDecoder(OboeDecoder);
         isInvalid = True;
     endcase
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: decoded_inst.rs1,
-      rs2: 0,
-      rd: decoded_inst.rd,
-      imm: i_imm,
-      csr: 0,
-      fu: tagged ALU alu_ctrl,
-      trap: (isInvalid)? tagged Valid TrapCause {isInterrupt: False, code: 2} : tagged Invalid
+    return BackendInst {
+      pc:   ?,
+      rs1:  decoded_inst.rs1,
+      rs2:  0,
+      rd:   decoded_inst.rd,
+      imm:  immIType(decoded_inst),
+      fu:   tagged ALU alu_ctrl,
+      trap: (isInvalid)? tagged Valid illegal_instruction : tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opLuiDecode
+  // Function: decodeLui
   //   Decode the instructions with opcode = LUI.
-  function BackendInst opLuiDecode(RawInst inst);
+  function BackendInst decodeLui(RawInst inst);
     UType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     AluCtrl alu_ctrl = AluCtrl {op: ADD, src: Rs1Imm};  // default value
-    Word u_imm = {inst[31:12], 12'b0};
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: 0,
-      rs2: 0,
-      rd: decoded_inst.rd,
-      imm: u_imm,
-      csr: 0,
-      fu: tagged ALU alu_ctrl,
+    return BackendInst {
+      pc:   ?,
+      rs1:  0,
+      rs2:  0,
+      rd:   decoded_inst.rd,
+      imm:  immUType(decoded_inst),
+      fu:   tagged ALU alu_ctrl,
       trap: tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opAuipcDecode
+  // Function: decodeAuipc
   //   Decode the instructions with opcode = AUIPC.
-  function BackendInst opAuipcDecode(RawInst inst);
+  function BackendInst decodeAuipc(RawInst inst);
     UType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     AluCtrl alu_ctrl = AluCtrl {op: ADD, src: PcImm};  // default value
-    Word u_imm = {inst[31:12], 12'b0};
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: 0,
-      rs2: 0,
-      rd: decoded_inst.rd,
-      imm: u_imm,
-      csr: 0,
-      fu: tagged ALU alu_ctrl,
+    return BackendInst {
+      pc:   ?,
+      rs1:  0,
+      rs2:  0,
+      rd:   decoded_inst.rd,
+      imm:  immUType(decoded_inst),
+      fu:   tagged ALU alu_ctrl,
       trap: tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opRDecode
+  // Function: decodeOp
   //   Decode the instructions with opcode = OP.
-  function BackendInst opRDecode(RawInst inst);
+  function BackendInst decodeOp(RawInst inst);
     RType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     AluCtrl alu_ctrl = AluCtrl {op: ADD, src: Rs1Rs2};  // default value
-
     Bool isInvalid = False;
-    if (decoded_inst.funct3 != 'b101 && decoded_inst.funct3 != 'b000) begin
-      isInvalid = (decoded_inst.funct7 != 0);
-    end
 
-    case (decoded_inst.funct3)
-      'b000: begin 
-        if (decoded_inst.funct7 == 0)
-          alu_ctrl = AluCtrl {op: ADD, src: Rs1Rs2};
-        else if (decoded_inst.funct7 == 'b00100000)
-          alu_ctrl = AluCtrl {op: SUB, src: Rs1Rs2};
-        else isInvalid = True;
-      end
-      'b010: alu_ctrl = AluCtrl {op: LT, src: Rs1Rs2};
-      'b011: alu_ctrl = AluCtrl {op: LTU, src: Rs1Rs2};
-      'b111: alu_ctrl = AluCtrl {op: AND, src: Rs1Rs2};
-      'b110: alu_ctrl = AluCtrl {op: OR, src: Rs1Rs2};
-      'b100: alu_ctrl = AluCtrl {op: XOR, src: Rs1Rs2};
-      'b001: alu_ctrl = AluCtrl {op: SLL, src: Rs1Rs2};
-      'b101: begin 
-        if (decoded_inst.funct7 == 0)
-          alu_ctrl = AluCtrl {op: SRL, src: Rs1Rs2};
-        else if (decoded_inst.funct7 == 'b00100000)
-          alu_ctrl = AluCtrl {op: SRA, src: Rs1Rs2};
-        else isInvalid = True;
-      end
+    case ({decoded_inst.funct7, decoded_inst.funct3})
+      {'b0000000, funct3_add}:  alu_ctrl = AluCtrl {op: ADD, src: Rs1Rs2}; 
+      {'b0100000, funct3_add}:  alu_ctrl = AluCtrl {op: SUB, src: Rs1Rs2}; 
+      {'b0000000, funct3_slt}:  alu_ctrl = AluCtrl {op: LT,  src: Rs1Rs2};
+      {'b0000000, funct3_sltu}: alu_ctrl = AluCtrl {op: LTU, src: Rs1Rs2};
+      {'b0000000, funct3_and}:  alu_ctrl = AluCtrl {op: AND, src: Rs1Rs2};
+      {'b0000000, funct3_or}:   alu_ctrl = AluCtrl {op: OR,  src: Rs1Rs2};
+      {'b0000000, funct3_xor}:  alu_ctrl = AluCtrl {op: XOR, src: Rs1Rs2};
+      {'b0000000, funct3_sll}:  alu_ctrl = AluCtrl {op: SLL, src: Rs1Rs2};
+      {'b0000000, funct3_srl}:  alu_ctrl = AluCtrl {op: SRL, src: Rs1Rs2}; 
+      {'b0100000, funct3_srl}:  alu_ctrl = AluCtrl {op: SRA, src: Rs1Rs2};
       default: isInvalid = True;
     endcase
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: decoded_inst.rs1,
-      rs2: decoded_inst.rs2,
-      rd: decoded_inst.rd,
-      imm: 0,
-      csr: 0,
-      fu: tagged ALU alu_ctrl,
-      trap: (isInvalid)? tagged Valid TrapCause {isInterrupt: False, code: 2} : tagged Invalid
+    return BackendInst {
+      pc:   ?,
+      rs1:  decoded_inst.rs1,
+      rs2:  decoded_inst.rs2,
+      rd:   decoded_inst.rd,
+      imm:  0,
+      fu:   tagged ALU alu_ctrl,
+      trap: (isInvalid)? tagged Valid illegal_instruction : tagged Invalid
     };
-    return return_inst;
   endfunction
   
-  // Function: opJalDecode
+  // Function: decodeJal
   //   Decode the instructions with opcode = JAL.
-  function BackendInst opJalDecode(RawInst inst);
-    UType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
+  function BackendInst decodeJal(RawInst inst);
+    JType decoded_inst = unpack(inst);
     BruCtrl bru_ctrl = BruCtrl {op: JAL, src: PcImm};  // default value
-    Word j_imm = signExtend({inst[31], inst[19:12], inst[20], inst[30:21], 1'b0}); 
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: 0,
-      rs2: 0,
-      rd: decoded_inst.rd,
-      imm: j_imm,
-      csr: 0,
-      fu: tagged BRU bru_ctrl,
+    return BackendInst {
+      pc:   ?,
+      rs1:  0,
+      rs2:  0,
+      rd:   decoded_inst.rd,
+      imm:  immJType(decoded_inst),
+      fu:   tagged BRU bru_ctrl,
       trap: tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opJalrDecode
+  // Function: decodeJalr
   //   Decode the instructions with opcode = JALR.
-  function BackendInst opJalrDecode(RawInst inst);
+  function BackendInst decodeJalr(RawInst inst);
     IType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     BruCtrl bru_ctrl = BruCtrl {op: JAL, src: Rs1Imm};  // default value
-    Word i_imm = signExtend(inst[31:20]);
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: decoded_inst.rs1,
-      rs2: 0,
-      rd: decoded_inst.rd,
-      imm: i_imm,
-      csr: 0,
-      fu: tagged BRU bru_ctrl,
+    return BackendInst {
+      pc:   ?,
+      rs1:  decoded_inst.rs1,
+      rs2:  0,
+      rd:   decoded_inst.rd,
+      imm:  immIType(decoded_inst),
+      fu:   tagged BRU bru_ctrl,
       trap: tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opBranchDecode
+  // Function: decodeBranch
   //   Decode the instructions with opcode = BRANCH.
-  function BackendInst opBranchDecode(RawInst inst);
-    SType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
+  function BackendInst decodeBranch(RawInst inst);
+    BType decoded_inst = unpack(inst);
     BruCtrl bru_ctrl = BruCtrl {op: EQ, src: PcImm};  // default value
-    Word b_imm = signExtend({inst[31], inst[7], inst[30:25], inst[11:8], 1'b0});
-
     Bool isInvalid = False;
 
     case (decoded_inst.funct3)
-      'b000: bru_ctrl = BruCtrl {op: EQ, src: PcImm};
-      'b001: bru_ctrl = BruCtrl {op: NE, src: PcImm};
-      'b100: bru_ctrl = BruCtrl {op: LT, src: PcImm};
-      'b101: bru_ctrl = BruCtrl {op: GE, src: PcImm};
-      'b110: bru_ctrl = BruCtrl {op: LTU, src: PcImm};
-      'b111: bru_ctrl = BruCtrl {op: GEU, src: PcImm};
+      funct3_beq:  bru_ctrl = BruCtrl {op: EQ,  src: PcImm};
+      funct3_bne:  bru_ctrl = BruCtrl {op: NE,  src: PcImm};
+      funct3_blt:  bru_ctrl = BruCtrl {op: LT,  src: PcImm};
+      funct3_bge:  bru_ctrl = BruCtrl {op: GE,  src: PcImm};
+      funct3_bltu: bru_ctrl = BruCtrl {op: LTU, src: PcImm};
+      funct3_bgeu: bru_ctrl = BruCtrl {op: GEU, src: PcImm};
       default: isInvalid = True;
     endcase
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: decoded_inst.rs1,
-      rs2: decoded_inst.rs2,
-      rd: 0,
-      imm: b_imm,
-      csr: 0,
-      fu: tagged BRU bru_ctrl,
-      trap: (isInvalid)? tagged Valid TrapCause {isInterrupt: False, code: 2} : tagged Invalid
+    return BackendInst {
+      pc:   ?,
+      rs1:  decoded_inst.rs1,
+      rs2:  decoded_inst.rs2,
+      rd:   0,
+      imm:  immBType(decoded_inst),
+      fu:   tagged BRU bru_ctrl,
+      trap: (isInvalid)? tagged Valid illegal_instruction : tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opLoadDecode
+  // Function: decodeLoad
   //   Decode the instructions with opcode = LOAD.
-  function BackendInst opLoadDecode(RawInst inst);
+  function BackendInst decodeLoad(RawInst inst);
     IType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     LsuCtrl lsu_ctrl = LsuCtrl {op: LW, src: Rs1Imm};  // default value
-    Word i_imm = signExtend(inst[31:20]);
-
     Bool isInvalid = False;
 
     case (decoded_inst.funct3)
-      'b000: lsu_ctrl = LsuCtrl {op: LB, src: Rs1Imm};
-      'b001: lsu_ctrl = LsuCtrl {op: LH, src: Rs1Imm};
-      'b010: lsu_ctrl = LsuCtrl {op: LW, src: Rs1Imm};
-      'b100: lsu_ctrl = LsuCtrl {op: LBU, src: Rs1Imm};
-      'b101: lsu_ctrl = LsuCtrl {op: LHU, src: Rs1Imm};
+      funct3_lb:  lsu_ctrl = LsuCtrl {op: LB, src: Rs1Imm};
+      funct3_lh:  lsu_ctrl = LsuCtrl {op: LH, src: Rs1Imm};
+      funct3_lw:  lsu_ctrl = LsuCtrl {op: LW, src: Rs1Imm};
+      funct3_lbu: lsu_ctrl = LsuCtrl {op: LBU, src: Rs1Imm};
+      funct3_lhu: lsu_ctrl = LsuCtrl {op: LHU, src: Rs1Imm};
       default: isInvalid = True;
     endcase
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: decoded_inst.rs1,
-      rs2: 0,
-      rd: decoded_inst.rd,
-      imm: i_imm,
-      csr: 0,
-      fu: tagged LSU lsu_ctrl,
-      trap: (isInvalid)? tagged Valid TrapCause {isInterrupt: False, code: 2} : tagged Invalid
+    return BackendInst {
+      pc:   ?,
+      rs1:  decoded_inst.rs1,
+      rs2:  0,
+      rd:   decoded_inst.rd,
+      imm:  immIType(decoded_inst),
+      fu:   tagged LSU lsu_ctrl,
+      trap: (isInvalid)? tagged Valid illegal_instruction : tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opStoreDecode
+  // Function: decodeStore
   //   Decode the instructions with opcode = STORE.
-  function BackendInst opStoreDecode(RawInst inst);
+  function BackendInst decodeStore(RawInst inst);
     SType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     LsuCtrl lsu_ctrl = LsuCtrl {op: SW, src: Rs1Rs2Imm};  // default value
-    Word s_imm = signExtend({inst[31:25], inst[11:7]});
-
     Bool isInvalid = False;
 
     case (decoded_inst.funct3)
-      'b000: lsu_ctrl = LsuCtrl {op: SB, src: Rs1Rs2Imm};
-      'b001: lsu_ctrl = LsuCtrl {op: SH, src: Rs1Rs2Imm};
-      'b010: lsu_ctrl = LsuCtrl {op: SW, src: Rs1Rs2Imm};
+      funct3_sb: lsu_ctrl = LsuCtrl {op: SB, src: Rs1Rs2Imm};
+      funct3_sh: lsu_ctrl = LsuCtrl {op: SH, src: Rs1Rs2Imm};
+      funct3_sw: lsu_ctrl = LsuCtrl {op: SW, src: Rs1Rs2Imm};
       default: isInvalid = True;
     endcase
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: decoded_inst.rs1,
-      rs2: decoded_inst.rs2,
-      rd: 0,
-      imm: s_imm,
-      csr: 0,
-      fu: tagged LSU lsu_ctrl,
-      trap: (isInvalid)? tagged Valid TrapCause {isInterrupt: False, code: 2} : tagged Invalid
+    return BackendInst {
+      pc:   ?,
+      rs1:  decoded_inst.rs1,
+      rs2:  decoded_inst.rs2,
+      rd:   0,
+      imm:  immSType(decoded_inst),
+      fu:   tagged LSU lsu_ctrl,
+      trap: (isInvalid)? tagged Valid illegal_instruction : tagged Invalid
     };
-    return return_inst;
   endfunction
 
-  // Function: opCsrDecode
+  // Function: decodeSystem
   //   Decode the instructions with opcode = CSR.
-  function BackendInst opCsrDecode(RawInst inst);
+  function BackendInst decodeSystem(RawInst inst);
     IType decoded_inst = unpack(inst);
-
-    BackendInst return_inst;
     CsruCtrl csru_ctrl = CsruCtrl {op: RW, src: Rs1};  // default value
-
     Bool isInvalid = False;
 
     case (decoded_inst.funct3)
-      'b001: csru_ctrl = CsruCtrl {op: RW, src: Rs1};
-      'b010: csru_ctrl = CsruCtrl {op: RS, src: Rs1};
-      'b011: csru_ctrl = CsruCtrl {op: RC, src: Rs1};
-      'b101: csru_ctrl = CsruCtrl {op: RW, src: Uimm};
-      'b110: csru_ctrl = CsruCtrl {op: RS, src: Uimm};
-      'b111: csru_ctrl = CsruCtrl {op: RC, src: Uimm};
+      funct3_csrrw:  csru_ctrl = CsruCtrl {op: RW, src: Rs1};
+      funct3_csrrs:  csru_ctrl = CsruCtrl {op: RS, src: Rs1};
+      funct3_csrrc:  csru_ctrl = CsruCtrl {op: RC, src: Rs1};
+      funct3_csrrwi: csru_ctrl = CsruCtrl {op: RW, src: Uimm};
+      funct3_csrrsi: csru_ctrl = CsruCtrl {op: RS, src: Uimm};
+      funct3_csrrci: csru_ctrl = CsruCtrl {op: RC, src: Uimm};
+      funct3_priv: begin
+        // TODO: decode privileged instructions
+        isInvalid = True;
+      end
       default: isInvalid = True;
     endcase
 
-    return_inst = BackendInst {
-      pc: ?,
-      rs1: decoded_inst.rs1,
-      rs2: 0,
-      rd: decoded_inst.rd,
-      imm: zeroExtend(pack(decoded_inst.rs1)),
-      csr: unpack(decoded_inst.imm),
-      fu: tagged CSRU csru_ctrl,
-      trap: (isInvalid)? tagged Valid TrapCause {isInterrupt: False, code: 2} : tagged Invalid
+    return BackendInst {
+      pc:   ?,
+      rs1:  decoded_inst.rs1,
+      rs2:  0,
+      rd:   decoded_inst.rd,
+      imm:  zeroExtend(decoded_inst.imm),
+      fu:   tagged CSRU csru_ctrl,
+      trap: (isInvalid)? tagged Valid illegal_instruction : tagged Invalid
     };
-    return return_inst;
   endfunction
 
   method BackendInst decode(RawInst inst, Word pc);
-    BackendInst return_inst = BackendInst {  // default value
-      pc: pc,
-      rs1: 0,
-      rs2: 0,
-      rd: 0,
-      imm: 0,
-      csr: 0,
-      fu: tagged ALU AluCtrl {op: ADD, src: Rs1Imm},
-      trap: tagged Invalid
-    };
+    BackendInst return_inst = ?;
+    Opcode opcode = inst[6:0];
 
-    Bit#(OpCodeWidth) opcode = inst[6:0];
-
+    // Decode instructoin based on its opcode.
     case (opcode)
-      op_imm    : return_inst = opImmDecode(inst);
-      op_r      : return_inst = opRDecode(inst);
-      op_lui    : return_inst = opLuiDecode(inst);
-      op_auipc  : return_inst = opAuipcDecode(inst);
-      op_jal    : return_inst = opJalDecode(inst);
-      op_jalr   : return_inst = opJalrDecode(inst);
-      op_branch : return_inst = opBranchDecode(inst);
-      op_load   : return_inst = opLoadDecode(inst);
-      op_store  : return_inst = opStoreDecode(inst);
-      op_csr    : return_inst = opCsrDecode(inst);
-      default   : return_inst.trap = tagged Valid TrapCause {isInterrupt: False, code: 2};
+      opcode_op_imm: return_inst = decodeOpImm(inst);
+      opcode_op:     return_inst = decodeOp(inst);
+      opcode_lui:    return_inst = decodeLui(inst);
+      opcode_auipc:  return_inst = decodeAuipc(inst);
+      opcode_jal:    return_inst = decodeJal(inst);
+      opcode_jalr:   return_inst = decodeJalr(inst);
+      opcode_branch: return_inst = decodeBranch(inst);
+      opcode_load:   return_inst = decodeLoad(inst);
+      opcode_store:  return_inst = decodeStore(inst);
+      opcode_system: return_inst = decodeSystem(inst);
+      default: return_inst.trap = tagged Valid illegal_instruction;
     endcase
 
     return_inst.pc = pc;
 
     if (isValid(return_inst.trap)) begin
-      return_inst.fu = tagged ALU AluCtrl {op: ADD, src: Rs1Imm};
+      return_inst.fu = tagged Invalid;
       return_inst.rs1 = 0;
       return_inst.rs2 = 0;
       return_inst.rd = 0;
       return_inst.imm = 0;
-      return_inst.csr = 0;
     end
+
     return return_inst;
   endmethod
+
 endmodule
+
 endpackage

--- a/src/OboeDecoder.bsv
+++ b/src/OboeDecoder.bsv
@@ -22,8 +22,6 @@ function Word immJType(JType inst) = signExtend({inst.imm4, inst.imm3, inst.imm2
 //   Generate B-type immediate value
 function Word immBType(BType inst) = signExtend({inst.imm4, inst.imm3, inst.imm2, inst.imm1, 1'b0}); 
 
-TrapCause illegal_instruction = TrapCause {isInterrupt: False, code: 2};
-
 // Interface: OboeDecoder
 interface OboeDecoder;
   // Method: decode

--- a/src/OboeDecoder.bsv
+++ b/src/OboeDecoder.bsv
@@ -266,7 +266,7 @@ module mkOboeDecoder(OboeDecoder);
   endfunction
 
   // Function: decodeSystem
-  //   Decode the instructions with opcode = CSR.
+  //   Decode the instructions with opcode = SYSTEM.
   function BackendInst decodeSystem(RawInst inst);
     IType decoded_inst = unpack(inst);
     CsruCtrl csru_ctrl = CsruCtrl {op: RW, src: Rs1};  // default value

--- a/src/OboeTypeDef.bsv
+++ b/src/OboeTypeDef.bsv
@@ -149,6 +149,9 @@ typedef struct {
   Bit#(31) code;
 } TrapCause deriving(Bits, FShow);
 
+// TODO: add more trap causes here
+TrapCause illegal_instruction = TrapCause {isInterrupt: False, code: 2};
+
 /////////////////////////////////////////////////
 // Section: Microarchitecture type definitions //
 /////////////////////////////////////////////////

--- a/src/OboeTypeDef.bsv
+++ b/src/OboeTypeDef.bsv
@@ -2,6 +2,10 @@ package OboeTypeDef;
 
 import OboeConfig::*;
 
+/////////////////////////////////////
+// Section: RISC-V ISA Definitions //
+/////////////////////////////////////
+
 // Typedef: XLEN
 //   RISC-V XLEN.
 typedef 32 XLEN;
@@ -18,6 +22,137 @@ Integer kNumArchRegs = valueOf(NumArchRegs);
 //   Architectural register ID/specifier type.
 typedef UInt#(TLog#(NumArchRegs)) ArchRegId;
 
+typedef Bit#(7) Opcode;
+
+Opcode opcode_op_imm = 'b0010011;
+Opcode opcode_op     = 'b0110011;
+Opcode opcode_lui    = 'b0110111;
+Opcode opcode_auipc  = 'b0010111;
+Opcode opcode_jal    = 'b1101111;
+Opcode opcode_jalr   = 'b1100111;
+Opcode opcode_branch = 'b1100011;
+Opcode opcode_load   = 'b0000011;
+Opcode opcode_store  = 'b0100011;
+Opcode opcode_system = 'b1110011;
+
+typedef Bit#(3) Funct3;
+
+Funct3 funct3_add  = 'b000;
+Funct3 funct3_sll  = 'b001;
+Funct3 funct3_slt  = 'b010;
+Funct3 funct3_sltu = 'b011;
+Funct3 funct3_xor  = 'b100;
+Funct3 funct3_srl  = 'b101;
+Funct3 funct3_or   = 'b110;
+Funct3 funct3_and  = 'b111;
+
+Funct3 funct3_lb   = 'b000;
+Funct3 funct3_lh   = 'b001;
+Funct3 funct3_lw   = 'b010;
+Funct3 funct3_lbu  = 'b100;
+Funct3 funct3_lhu  = 'b101;
+
+Funct3 funct3_sb   = 'b000;
+Funct3 funct3_sh   = 'b001;
+Funct3 funct3_sw   = 'b010;
+
+Funct3 funct3_beq  = 'b000;
+Funct3 funct3_bne  = 'b001;
+Funct3 funct3_blt  = 'b100;
+Funct3 funct3_bge  = 'b101;
+Funct3 funct3_bltu = 'b110;
+Funct3 funct3_bgeu = 'b111;
+
+Funct3 funct3_csrrw  = 'b001;
+Funct3 funct3_csrrs  = 'b010;
+Funct3 funct3_csrrc  = 'b011;
+Funct3 funct3_csrrwi = 'b101;
+Funct3 funct3_csrrsi = 'b110;
+Funct3 funct3_csrrci = 'b111;
+Funct3 funct3_priv   = 'b000;
+
+typedef Bit#(7) Funct7;
+
+typedef Bit#(12) Funct12;
+
+Funct12 funct12_mret = 'b0011_0000_0010;  // trap return
+Funct12 funct12_wfi  = 'b0001_0000_0101;  // interrupt management
+
+// Typedef: RType
+//   R-type instruction format.
+typedef struct {
+  Funct7    funct7;
+  ArchRegId rs2;
+  ArchRegId rs1;
+  Funct3    funct3;
+  ArchRegId rd;
+  Opcode    opcode;
+} RType deriving(Eq, Bits);
+
+// Typedef: IType
+//   I-type instruction format.
+typedef struct {
+  Bit#(12)  imm;
+  ArchRegId rs1;
+  Funct3    funct3;
+  ArchRegId rd;
+  Opcode    opcode;
+} IType deriving(Eq, Bits);
+
+// Typedef: SType
+//   S-type instruction format.
+typedef struct {
+  Bit#(7)   imm2;
+  ArchRegId rs2;
+  ArchRegId rs1;
+  Funct3    funct3;
+  Bit#(5)   imm1;
+  Opcode    opcode;
+} SType deriving(Eq, Bits);
+
+// Typedef: BType
+//   B-type instruction format.
+typedef struct {
+  Bit#(1)   imm4;
+  Bit#(6)   imm2;
+  ArchRegId rs2;
+  ArchRegId rs1;
+  Funct3    funct3;
+  Bit#(4)   imm1;
+  Bit#(1)   imm3;
+  Opcode    opcode;
+} BType deriving(Eq, Bits);
+
+// Typedef: UType
+//   U-type instruction format.
+typedef struct {
+  Bit#(20)  imm;
+  ArchRegId rd;
+  Opcode    opcode;
+} UType deriving(Eq, Bits);
+
+// Typedef: JType
+//   U-type instruction format.
+typedef struct {
+  Bit#(1)   imm4;
+  Bit#(10)  imm1;
+  Bit#(1)   imm2;
+  Bit#(8)   imm3;
+  ArchRegId rd;
+  Opcode    opcode;
+} JType deriving(Eq, Bits);
+
+// Typedef: TrapCause
+//   Define the trap type and cause
+typedef struct {
+  Bool     isInterrupt;
+  Bit#(31) code;
+} TrapCause deriving(Bits, FShow);
+
+/////////////////////////////////////////////////
+// Section: Microarchitecture type definitions //
+/////////////////////////////////////////////////
+
 // Typedef: TagWidth
 //   Bit width of <Tag>.
 typedef TLog#(NumPhysicalRegs) TagWidth;
@@ -33,9 +168,6 @@ typedef Bit#(XLEN) Word;
 // Typdef: CsrId
 //   Identifier of CSR
 typedef UInt#(12) CsrId;
-
-
-// Section: Decoder type definitions
 
 // Typedef: RawInst
 //   XLEN-width raw RISC-V instruction.
@@ -155,13 +287,6 @@ typedef union tagged {
   LsuCtrl  LSU;
 } FunctionUnit deriving(Bits, Eq, FShow);
 
-// Typedef: TrapCause
-//   Define the trap type and cause
-typedef struct {
-  Bool isInterrupt;
-  Bit#(31) code;
-} TrapCause deriving(Bits, FShow);
-
 // Typedef: BackendInst
 //   Structure for decoded instruction.
 typedef struct {
@@ -171,9 +296,7 @@ typedef struct {
   ArchRegId         rd;
   Word              imm;
   FunctionUnit      fu;
-  CsrId             csr;
   Maybe#(TrapCause) trap;
 } BackendInst deriving(Bits, FShow);
-
 
 endpackage

--- a/src/OboeTypeDef.bsv
+++ b/src/OboeTypeDef.bsv
@@ -132,7 +132,7 @@ typedef struct {
 } UType deriving(Eq, Bits);
 
 // Typedef: JType
-//   U-type instruction format.
+//   J-type instruction format.
 typedef struct {
   Bit#(1)   imm4;
   Bit#(10)  imm1;


### PR DESCRIPTION
1. Moved ISA definitions to `OboeTypeDef.bsv`.
2. Added instruction encodings for `Funct3`, etc.
3. Aligned some tabular codes.
4. Added functions to generate various types of immediate value.
5. Use `imm` field for CSR ID and `rs1` also stores `uimm`.
6. Replaced `isInvalid` to `isIllegal`.